### PR TITLE
Improve configuration

### DIFF
--- a/examples/config.ini
+++ b/examples/config.ini
@@ -1,0 +1,41 @@
+# Sample configuration file
+# Modify then run "spider --config=/path/to/config.ini"
+# Uses INI-style syntax, see https://docs.python.org/3/library/configparser.html
+
+[COLLECTORS]
+# List of Collectors that should be queried for the location of Schedds.
+# Each Collector address must be on its own line.
+#cm.mypool.org
+
+[SCHEDDS]
+# List of Schedds that should be queried.
+# Each Schedd name should be on its own line.
+# If no Schedds are defined here, all Schedds located by the Collectors will
+# be queried.
+#submit1.mypool.org
+#submit2.mypool.org
+
+[PROCESS]
+#schedd_history = True
+#schedd_queue = False
+
+# Process at most $(max_documents) per Schedd, 0 [default] = process all documents.
+#max_documents = 0
+
+# Use multithreading to query $(parallel_queries) Schedds at the same time.
+#parallel_queries = 8
+
+[ELASTICSEARCH]
+#host = es.mypool.org
+#port = 9200
+#username = esuser
+#password = changeme
+#bunch_size = 250
+
+#feed_schedd_history = False
+#feed_schedd_queue = False
+
+# Documents are placed in indexes named $(index_name)-YYYY-MM-DD (shard per day)
+# with the date generated from $(index_date_attr) ("CompletionDate" by default)
+#index_name = htcondor_jobs
+#index_date_attr = CompletionDate

--- a/examples/config.ini
+++ b/examples/config.ini
@@ -26,6 +26,8 @@
 #parallel_queries = 8
 
 [ELASTICSEARCH]
+# https requires that certifi be installed
+#use_https = False
 #host = es.mypool.org
 #port = 9200
 #username = esuser

--- a/htcondor_es/elastic.py
+++ b/htcondor_es/elastic.py
@@ -108,7 +108,7 @@ def get_server_handle(args=None):
                 "Call get_server_handle with args first to create ES interface instance"
             )
             return _ES_HANDLE
-        _ES_HANDLE = ElasticInterface(hostname=args.es_hostname, port=args.es_port)
+        _ES_HANDLE = ElasticInterface(hostname=args.es_host, port=args.es_port)
     return _ES_HANDLE
 
 

--- a/htcondor_es/elastic.py
+++ b/htcondor_es/elastic.py
@@ -109,7 +109,8 @@ def get_server_handle(args=None):
                 "Call get_server_handle with args first to create ES interface instance"
             )
             return _ES_HANDLE
-        _ES_HANDLE = ElasticInterface(hostname=args.es_host, port=args.es_port)
+        _ES_HANDLE = ElasticInterface(hostname=args.es_host, port=args.es_port,
+          username=args.es_username, password=args.es_password, use_https=args.es_use_https)
     return _ES_HANDLE
 
 

--- a/htcondor_es/history.py
+++ b/htcondor_es/history.py
@@ -73,8 +73,12 @@ def process_schedd(
 
                 continue
 
+            # Index based on timestamp attr in config, otherwise fallback to
+            # EnteredCurrentStatus, QDate, then finally current time
             idx = elastic.get_index(
-                job_ad.get(args.es_index_date_attr, int(time.time())),
+                job_ad.get(args.es_index_date_attr,
+                               job_ad.get("EnteredCurrentStatus",
+                                              job_ad.get("QDate", int(time.time())))),
                 template=args.es_index_name,
                 update_es=(args.es_feed_schedd_history and not args.read_only),
             )

--- a/htcondor_es/history.py
+++ b/htcondor_es/history.py
@@ -96,7 +96,7 @@ def process_schedd(
                 continue
 
             idx = elastic.get_index(
-                index_time(args.es_index_date_attr, ad),
+                index_time(args.es_index_date_attr, job_ad),
                 template=args.es_index_name,
                 update_es=(args.es_feed_schedd_history and not args.read_only),
             )

--- a/htcondor_es/history.py
+++ b/htcondor_es/history.py
@@ -26,13 +26,16 @@ def index_time(index_attr, ad):
         - else QDate if present
         - else fall back to launch time
     """
-    if ad.get(index_attr, 0) > 0:
-        return ad[args.es_index_attr]
-    
-    elif ad.get("EnteredCurrentStatus", 0) > 0:
+    try:
+        if int(ad.get(index_attr, 0)) > 0:
+            return ad[index_attr]
+    except (ValueError, TypeError):
+        logging.error(f"The value of {index_attr} is not numeric and cannot be used as a timestamp, falling back to EnteredCurrentStatus")
+
+    if ad.get("EnteredCurrentStatus", 0) > 0:
         return ad["EnteredCurrentStatus"]
 
-    elif ad.get("QDate", 0) > 0:
+    if ad.get("QDate", 0) > 0:
         return ad["QDate"]
 
     return _LAUNCH_TIME

--- a/htcondor_es/spider.py
+++ b/htcondor_es/spider.py
@@ -185,7 +185,7 @@ def main():
         dest="log_dir",
         help=(
             "Directory for logging information "
-            "[default: %(default)s]"
+            "[default: log/]"
         ),
     )
     parser.add_argument(
@@ -195,7 +195,7 @@ def main():
         dest="log_level",
         help=(
             "Log level (CRITICAL/ERROR/WARNING/INFO/DEBUG) "
-            "[default: %(default)s]"
+            "[default: WARNING]"
         ),
     )
     parser.add_argument(

--- a/htcondor_es/spider.py
+++ b/htcondor_es/spider.py
@@ -22,20 +22,13 @@ def main_driver(args):
 
     # Get all the schedd ads
     schedd_ads = []
-    if args.collectors_file:
-        schedd_ads = utils.get_schedds_from_file(
-            args, collectors_file=args.collectors_file
-        )
-        # sending a file through postprocessing will cause problems.
-        del args.collectors_file
-    else:
-        schedd_ads = utils.get_schedds(args, collectors=args.collectors)
+    schedd_ads = get_schedds(args)
     logging.warning("&&& There are %d schedds to query.", len(schedd_ads))
 
-    with multiprocessing.Pool(processes=args.query_pool_size) as pool:
+    with multiprocessing.Pool(processes=args.process_parallel_queries) as pool:
         metadata = utils.collect_metadata()
 
-        if not args.skip_history:
+        if args.process_schedd_history:
             history.process_histories(
                 schedd_ads=schedd_ads,
                 starttime=starttime,
@@ -45,7 +38,7 @@ def main_driver(args):
             )
 
         # Now that we have the fresh history, process the queues themselves.
-        if args.process_queue:
+        if args.process_schedd_queue:
             queues.process_queues(
                 schedd_ads=schedd_ads,
                 starttime=starttime,
@@ -67,37 +60,153 @@ def main():
 
     Parses arguments and invokes main_driver
     """
+    defaults = default_config()
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--process_queue",
-        action="store_true",
-        dest="process_queue",
-        help="Process also schedd queue (Running/Idle/Pending jobs)",
-    )
-    parser.add_argument(
-        "--feed_es", action="store_true", dest="feed_es", help="Feed to Elasticsearch"
-    )
-    parser.add_argument(
-        "--feed_es_for_queues",
-        action="store_true",
-        dest="feed_es_for_queues",
-        help="Feed queue data also to Elasticsearch",
-    )
-
-    parser.add_argument(
-        "--schedd_filter",
-        default="",
-        type=str,
-        dest="schedd_filter",
+        "--config_file",
+        dest="config_file",
         help=(
-            "Comma separated list of schedd names to process [default is to process all]"
+            "File containing configuration for the spider script. "
+            "Config file values will be overridden by commandline arguments."
         ),
     )
     parser.add_argument(
-        "--skip_history",
-        action="store_true",
-        dest="skip_history",
-        help="Skip processing the history. (Only do queues.)",
+        "--collectors",
+        dest="collectors",
+        help="Comma-separated list of Collector addresses used to locate Schedds",
+    )
+    parser.add_argument(
+        "--schedds",
+        dest="schedds",
+        help=(
+            "Comma-separated list of Schedd names to process "
+            "[default is to process all Schedds located by Collectors]"
+        ),
+    )
+    parser.add_argument(
+        "--skip_process_schedd_history",
+        action="store_const",
+        const=False,
+        dest="process_schedd_history",
+        help="Do not process Schedd history"
+    )
+    parser.add_argument(
+        "--process_schedd_queue",
+        action="store_const",
+        const=True,
+        dest="process_schedd_queue",
+        help="Process Schedd queue (Running/Idle/Pending jobs)",
+    )
+    parser.add_argument(
+        "--process_max_documents",
+        type=int,
+        dest="process_max_documents",
+        help=(
+            "Abort after this many documents (per Schedd). "
+            f"[default: {defaults['process_max_documents'] (process all)]"
+        ),
+    )
+    parser.add_argument(
+        "--process_parallel_queries",
+        type=int,
+        dest="process_parallel_queries",
+        help=(
+            "Number of parallel processes for querying "
+            f"[default: {defaults['process_parallel_queries']}]"
+        ),
+    )
+    parser.add_argument(
+        "--es_host",
+        dest="es_host",
+        help=(
+            "Host of the Elasticsearch instance to be used "
+            f"[default: {defaults['es_host']}]"
+        ),
+    )
+    parser.add_argument(
+        "--es_port",
+        type=int,
+        dest="es_port",
+        help=(
+            "Port of the Elasticsearch instance to be used "
+            f"[default: {defaults['es_port']}]"
+        )
+    )
+    parser.add_argument(
+        "--es_bunch_size",
+        type=int,
+        dest="es_bunch_size",
+        help=(
+            "Send docs to ES in bunches of this number "
+            f"[default: {defaults['es_bunch_size']}]"
+        )
+    )
+    parser.add_argument(
+        "--es_feed_schedd_history",
+        action="store_const",
+        const=True,
+        dest="es_feed_schedd_history",
+        help=(
+            "Feed Schedd history to Elasticsearch "
+            f"[default: {defaults['es_feed_schedd_history']}]"
+        )
+    )
+    parser.add_argument(
+        "--es_feed_schedd_queue",
+        action="store_const",
+        const=True,
+        dest="es_feed_schedd_queue",
+        help=(
+            "Feed Schedd queue to Elasticsearch ",
+            f"[default: {defaults['es_feed_schedd_queue']}]"
+        )
+    )
+    parser.add_argument(
+        "--es_index_name",
+        dest="es_index_name",
+        help=(
+            "Trunk of Elasticsearch index name "
+            f"[default: {es_index_name}]"
+        ),
+    )
+    parser.add_argument(
+        "--es_index_date_attr",
+        dest="es_index_date_attr",
+        help=(
+            "Job attribute to use as date for Elasticsearch index name "
+            "[default: {defaults['es_index_date_attr'}]"
+        ),
+    )
+
+    parser.add_argument(
+        "--log_dir",
+        default="log/",
+        type=str,
+        dest="log_dir",
+        help=(
+            "Directory for logging information "
+            "[default: %(default)s]"
+        ),
+    )
+    parser.add_argument(
+        "--log_level",
+        default="WARNING",
+        type=str,
+        dest="log_level",
+        help=(
+            "Log level (CRITICAL/ERROR/WARNING/INFO/DEBUG) "
+            "[default: %(default)s]"
+        ),
+    )
+    parser.add_argument(
+        "--email_alerts",
+        default=[],
+        action="append",
+        dest="email_alerts",
+        help=(
+            "Email addresses for alerts "
+            "[default: none]"
+        ),
     )
     parser.add_argument(
         "--read_only",
@@ -110,111 +219,13 @@ def main():
         action="store_true",
         dest="dry_run",
         help=(
-            "Don't even read info, just pretend to. (Still query the collector for the schedd's though.)"
+            "Don't even read info, just pretend to. (Still "
+            "query the collector for the Schedds though.)"
         ),
-    )
-    parser.add_argument(
-        "--max_documents_to_process",
-        default=0,
-        type=int,
-        dest="max_documents_to_process",
-        help=(
-            "Abort after this many documents (per schedd). [default: %(default)d (process all)]"
-        ),
-    )
-    parser.add_argument(
-        "--keep_full_queue_data",
-        action="store_true",
-        dest="keep_full_queue_data",
-        help="Drop all but some fields for running jobs.",
-    )
-    parser.add_argument(
-        "--es_bunch_size",
-        default=250,
-        type=int,
-        dest="es_bunch_size",
-        help="Send docs to ES in bunches of this number [default: %(default)d]",
-    )
-    parser.add_argument(
-        "--query_queue_batch_size",
-        default=50,
-        type=int,
-        dest="query_queue_batch_size",
-        help="Send docs to listener in batches of this number [default: %(default)d]",
-    )
-    parser.add_argument(
-        "--upload_pool_size",
-        default=8,
-        type=int,
-        dest="upload_pool_size",
-        help="Number of parallel processes for uploading [default: %(default)d]",
-    )
-    parser.add_argument(
-        "--query_pool_size",
-        default=8,
-        type=int,
-        dest="query_pool_size",
-        help="Number of parallel processes for querying [default: %(default)d]",
     )
 
-    parser.add_argument(
-        "--es_hostname",
-        default="localhost",
-        type=str,
-        dest="es_hostname",
-        help="Hostname of the elasticsearch instance to be used [default: %(default)s]",
-    )
-    parser.add_argument(
-        "--es_port",
-        default=9200,
-        type=int,
-        dest="es_port",
-        help="Port of the elasticsearch instance to be used [default: %(default)d]",
-    )
-    parser.add_argument(
-        "--es_index_template",
-        default="htcondor",
-        type=str,
-        dest="es_index_template",
-        help="Trunk of index pattern. [default: %(default)s]",
-    )
-    parser.add_argument(
-        "--log_dir",
-        default="log/",
-        type=str,
-        dest="log_dir",
-        help="Directory for logging information [default: %(default)s]",
-    )
-    parser.add_argument(
-        "--log_level",
-        default="WARNING",
-        type=str,
-        dest="log_level",
-        help="Log level (CRITICAL/ERROR/WARNING/INFO/DEBUG) [default: %(default)s]",
-    )
-    parser.add_argument(
-        "--email_alerts",
-        default=[],
-        action="append",
-        dest="email_alerts",
-        help="Email addresses for alerts [default: none]",
-    )
-    parser.add_argument(
-        "--collectors",
-        default=[],
-        action="append",
-        dest="collectors",
-        help="Collectors' addresses",
-    )
-    parser.add_argument(
-        "--collectors_file",
-        default=None,
-        action="store",
-        type=argparse.FileType("r"),
-        dest="collectors_file",
-        help="File defining the pools and collectors",
-    )
     args = parser.parse_args()
+    args = load_config(args)
     utils.set_up_logging(args)
 
     # --dry_run implies read_only

--- a/htcondor_es/spider.py
+++ b/htcondor_es/spider.py
@@ -22,7 +22,7 @@ def main_driver(args):
 
     # Get all the schedd ads
     schedd_ads = []
-    schedd_ads = get_schedds(args)
+    schedd_ads = utils.get_schedds(args)
     logging.warning("&&& There are %d schedds to query.", len(schedd_ads))
 
     with multiprocessing.Pool(processes=args.process_parallel_queries) as pool:
@@ -60,7 +60,7 @@ def main():
 
     Parses arguments and invokes main_driver
     """
-    defaults = default_config()
+    defaults = utils.default_config()
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--config_file",
@@ -225,7 +225,7 @@ def main():
     )
 
     args = parser.parse_args()
-    args = load_config(args)
+    args = utils.load_config(args)
     utils.set_up_logging(args)
 
     # --dry_run implies read_only

--- a/htcondor_es/spider.py
+++ b/htcondor_es/spider.py
@@ -103,7 +103,7 @@ def main():
         dest="process_max_documents",
         help=(
             "Abort after this many documents (per Schedd). "
-            f"[default: {defaults['process_max_documents'] (process all)]"
+            f"[default: {defaults['process_max_documents']} (process all)]"
         ),
     )
     parser.add_argument(

--- a/htcondor_es/spider.py
+++ b/htcondor_es/spider.py
@@ -157,7 +157,7 @@ def main():
         const=True,
         dest="es_feed_schedd_queue",
         help=(
-            "Feed Schedd queue to Elasticsearch ",
+            "Feed Schedd queue to Elasticsearch "
             f"[default: {defaults['es_feed_schedd_queue']}]"
         )
     )
@@ -185,7 +185,7 @@ def main():
         dest="log_dir",
         help=(
             "Directory for logging information "
-            "[default: log/]"
+            "[default: %(default)s]"
         ),
     )
     parser.add_argument(
@@ -195,7 +195,7 @@ def main():
         dest="log_level",
         help=(
             "Log level (CRITICAL/ERROR/WARNING/INFO/DEBUG) "
-            "[default: WARNING]"
+            "[default: %(default)s]"
         ),
     )
     parser.add_argument(

--- a/htcondor_es/spider.py
+++ b/htcondor_es/spider.py
@@ -166,7 +166,7 @@ def main():
         dest="es_index_name",
         help=(
             "Trunk of Elasticsearch index name "
-            f"[default: {es_index_name}]"
+            f"[default: {defaults['es_index_name']}]"
         ),
     )
     parser.add_argument(
@@ -174,7 +174,7 @@ def main():
         dest="es_index_date_attr",
         help=(
             "Job attribute to use as date for Elasticsearch index name "
-            "[default: {defaults['es_index_date_attr'}]"
+            "[default: {defaults['es_index_date_attr']}]"
         ),
     )
 

--- a/htcondor_es/utils.py
+++ b/htcondor_es/utils.py
@@ -16,6 +16,7 @@ import email.mime.text
 import json
 import logging
 import logging.handlers
+from argparse import Namespace
 
 import htcondor
 
@@ -65,50 +66,56 @@ def load_config(args):
         logging.exception("Fatal error while reading config file")
         sys.exit(1)
 
-    if (args.collectors is None) and ('COLLECTORS' in config) and (len(list(config['COLLECTORS'])) > 0):
-        args.collectors = ','.join(list(config['COLLECTORS']))
-    if (args.schedds is None) and ('SCHEDDS' in config) and (len(list(config['SCHEDDS'])) > 0):
-        args.schedds = ','.join(list(config['SCHEDDS']))
+    # convert args from a namespace object to a dict
+    args = vars(args)
+    if (args.get('collectors') is None) and ('COLLECTORS' in config) and (len(list(config['COLLECTORS'])) > 0):
+        args['collectors'] = ','.join(list(config['COLLECTORS']))
+    if (args.get('schedds') is None)    and ('SCHEDDS' in config)    and (len(list(config['SCHEDDS'])) > 0):
+        args['schedds']    = ','.join(list(config['SCHEDDS']))
     if 'PROCESS' in config:
         process = config['PROCESS']
-        if (args.process_schedd_history is None):
-            args.process_schedd_history = process.getboolean(
+        if args.get('process_schedd_history') is None:
+            args['process_schedd_history'] = process.getboolean(
                 'schedd_history', fallback=defaults['process_schedd_history'])
-        if (args.process_schedd_queue is None):
-            args.process_schedd_queue = process.getboolean(
+        if args.get('process_schedd_queue') is None:
+            args['process_schedd_queue'] = process.getboolean(
                 'schedd_queue', fallback=defaults['process_schedd_queue'])
-        if (args.process_max_documents is None):
-            args.process_max_documents = process.getint(
+        if args.get('process_max_documents') is None:
+            args['process_max_documents'] = process.getint(
                 'max_documents', fallback=defaults['process_max_documents'])
-        if (args.process_parallel_queries is None):
-            args.process_parallel_queries = process.getint(
+        if args.get('process_parallel_queries') is None:
+            args['process_parallel_queries'] = process.getint(
                 'parallel_queries', fallback=defaults['process_parallel_queries'])
     if 'ELASTICSEARCH' in config:
         es = config['ELASTICSEARCH']
-        if (args.es_host is None):
-            args.es_host = es.get('host', fallback=defaults['es_host'])
-        if (args.es_port is None):
-            args.es_port = es.get('port', fallback=defaults['es_port'])
-        if ('es_username' in args and args.es_username is None):
-            args.es_username = es.get('username', fallback=None)
-        if ('es_password' in args and args.es_password is None):
-            args.es_password = es.get('password', fallback=None)
-        if (args.es_bunch_size is None):
-            args.es_bunch_size = es.getint(
+        if args.get('es_host') is None:
+            args['es_host'] = es.get('host', fallback=defaults['es_host'])
+        if args.get('es_port') is None:
+            args['es_port'] = es.get('port', fallback=defaults['es_port'])
+        if args.get('es_username') is None:
+            args['es_username'] = es.get('username', fallback=None)
+        if args.get('es_password') is None:
+            args['es_password'] = es.get('password', fallback=None)
+        if args.get('es_use_https') is None:
+            args['es_use_https'] = es.getboolean('use_https', fallback=False)
+        if args.get('es_bunch_size') is None:
+            args['es_bunch_size'] = es.getint(
                 'bunch_size', fallback=defaults['es_bunch_size'])
-        if (args.es_feed_schedd_history is None):
-            args.es_feed_schedd_history = es.getboolean(
+        if args.get('es_feed_schedd_history') is None:
+            args['es_feed_schedd_history'] = es.getboolean(
                 'feed_schedd_history', fallback=defaults['es_feed_schedd_history'])
-        if (args.es_feed_schedd_queue is None):
-            args.es_feed_schedd_queue = es.getboolean(
+        if args.get('es_feed_schedd_queue') is None:
+            args['es_feed_schedd_queue'] = es.getboolean(
                 'feed_schedd_queue', fallback=defaults['es_feed_schedd_queue'])
-        if (args.es_index_name is None):
-            args.es_index_name = es.get(
+        if args.get('es_index_name') is None:
+            args['es_index_name'] = es.get(
                 'index_name', fallback=defaults['es_index_name'])
-        if (args.es_index_date_attr is None):
-            args.es_index_date_attr = es.get(
+        if args.get('es_index_date_attr') is None:
+            args['es_index_date_attr'] = es.get(
                 'index_date_attr', fallback=defaults['es_index_date_attr'])
 
+    # convert args back to a namespace object
+    args = Namespace(**args)
     return args
 
 

--- a/htcondor_es/utils.py
+++ b/htcondor_es/utils.py
@@ -22,25 +22,105 @@ import htcondor
 TIMEOUT_MINS = 11
 
 
-def get_schedds_from_file(args=None, collectors_file=None):
-    schedds = []
-    names = set()
+def default_config():
+    defaults = {
+        'process_schedd_history'   : True,
+        'process_schedd_queue'     : False,
+        'process_max_documents'    : 0,
+        'process_parallel_queries' : 8,
+        'es_host'                  : 'localhost',
+        'es_port'                  : 9200,
+        'es_bunch_size'            : 250,
+        'es_feed_schedd_history'   : False,
+        'es_feed_schedd_queue'     : False,
+        'es_index_name'            : 'htcondor_jobs',
+        'es_index_date_attr'       : 'CompletionDate',
+    }
+    return defaults
+
+
+def load_config(args):
+    defaults = default_config()
+    if (args is None) or (args.config_file is None):
+        return args
+
+    config = configparser.ConfigParser(
+        allow_no_value=True,
+        empty_lines_in_values=False)
     try:
-        pools = json.load(collectors_file)
-        for pool in pools:
-            _pool_schedds = get_schedds(args, collectors=pools[pool], pool_name=pool)
-            schedds.extend([s for s in _pool_schedds if s.get("Name") not in names])
-            names.update([s.get("Name") for s in _pool_schedds])
-    except (IOError, json.JSONDecodeError):
-        schedds = get_schedds(args)
-    return schedds
+        config_files = config.read(args.config_file)
+        if len(config_files) == 0:
+            # Something went wrong with reading the config file,
+            # hopefully open() generates an informative exception.
+            try:
+                open(args.config_file, 'rb').close()
+            except Exception:
+                raise
+            else:
+                # open() didn't error, so something else happened *shrug*
+                raise RuntimeError("Could not read config file. "
+                    "Please check that it exists, is readable, and is free of "
+                    "syntax errors.")
+    except Exception:
+        logging.exception("Fatal error while reading config file")
+        sys.exit(1)
+
+    if (args.collectors is None) and ('COLLECTORS' in config) and (len(list(config['COLLECTORS'])) > 0):
+        args.collectors = ','.join(list(config['COLLECTORS']))
+    if (args.schedds is None) and ('SCHEDDS' in config) and (len(list(config['SCHEDDS'])) > 0):
+        args.schedds = ','.join(list(config['SCHEDDS']))
+    if 'PROCESS' in config:
+        process = config['PROCESS']
+        if (args.process_schedd_history is None):
+            args.process_schedd_history = process.getboolean(
+                'schedd_history', fallback=defaults['process_schedd_history'])
+        if (args.process_schedd_queue is None):
+            args.process_schedd_queue = process.getboolean(
+                'schedd_queue', fallback=defaults['process_schedd_queue'])
+        if (args.process_max_documents is None):
+            args.process_max_documents = process.getint(
+                'max_documents', fallback=defaults['process_max_documents'])
+        if (args.process_parallel_queries is None):
+            args.process_parallel_queries = process.getint(
+                'parallel_queries', fallback=defaults['process_parallel_queries'])
+    if 'ELASTICSEARCH' in config:
+        es = config['ELASTICSEARCH']
+        if (args.es_host is None):
+            args.es_host = es.get('host', fallback=defaults['es_host'])
+        if (args.es_port is None):
+            args.es_port = es.get('port', fallback=defaults['es_port'])
+        if ('es_username' in args and args.es_username is None):
+            args.es_username = es.get('username', fallback=None)
+        if ('es_password' in args and args.es_password is None):
+            args.es_password = es.get('password', fallback=None)
+        if (args.es_bunch_size is None):
+            args.es_bunch_size = es.getint(
+                'bunch_size', fallback=defaults['es_bunch_size'])
+        if (args.es_feed_schedd_history is None):
+            args.es_feed_schedd_history = es.getboolean(
+                'feed_schedd_history', fallback=defaults['es_feed_schedd_history'])
+        if (args.es_feed_schedd_queue is None):
+            args.es_feed_schedd_queue = es.getboolean(
+                'feed_schedd_queue', fallback=defaults['es_feed_schedd_queue'])
+        if (args.es_index_name is None):
+            args.es_index_name = es.get(
+                'index_name', fallback=defaults['es_index_name'])
+        if (args.es_index_date_attr is None):
+            args.es_index_date_attr = es.get(
+                'index_date_attr', fallback=defaults['es_index_date_attr'])
+
+    return args
 
 
-def get_schedds(args=None, collectors=None, pool_name="Unknown"):
+def get_schedds(args=None):
     """
     Return a list of schedd ads representing all the schedds in the pool.
     """
-    collectors = collectors or []
+    collectors = args.collectors
+    if collectors:
+        collectors = collectors.split(',')
+    else:
+        collectors = []
 
     schedd_ads = {}
     for host in collectors:
@@ -52,6 +132,7 @@ def get_schedds(args=None, collectors=None, pool_name="Unknown"):
             continue
 
         for schedd in schedds:
+            schedd["MyPool"] = host
             try:
                 schedd_ads[schedd["Name"]] = schedd
             except KeyError:
@@ -60,8 +141,8 @@ def get_schedds(args=None, collectors=None, pool_name="Unknown"):
     schedd_ads = list(schedd_ads.values())
     random.shuffle(schedd_ads)
 
-    if args and args.schedd_filter:
-        return [s for s in schedd_ads if s["Name"] in args.schedd_filter.split(",")]
+    if args and args.schedds:
+        return [s for s in schedd_ads if s["Name"] in args.schedds.split(",")]
 
     return schedd_ads
 

--- a/htcondor_es/utils.py
+++ b/htcondor_es/utils.py
@@ -16,6 +16,7 @@ import email.mime.text
 import json
 import logging
 import logging.handlers
+import configparser
 from argparse import Namespace
 
 import htcondor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 htcondor
 elasticsearch
 requests
-certifi[https]
+certifi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 htcondor
 elasticsearch
 requests
+certifi[https]


### PR DESCRIPTION
- Add option to use config file
- Rename args to be consistent
- Sharding date attr now configurable instead of hardcoded to QDate
- Use CompletionDate instead of QDate by default
- No more collectors file, use a config file or comma-separated arg instead
- Add collector hostnamed to schedd add (Schedd object init still ok)

Resolves #3 

To do:
- [x] Use `es_username` and `es_password`
- [x] Fallbacks for date indexing attr