### PR TITLE
Initial attempt at polling startd histories

### DIFF
--- a/htcondor_es/history.py
+++ b/htcondor_es/history.py
@@ -357,7 +357,7 @@ def update_checkpoint(name, completion_date):
     checkpoint[name] = completion_date
 
     with open("checkpoint.json", "w") as fd:
-        json.dump(checkpoint, fd)
+        json.dump(checkpoint, fd, indent=4)
 
 
 def process_histories(schedd_ads = [], startd_ads = [],

--- a/htcondor_es/utils.py
+++ b/htcondor_es/utils.py
@@ -115,6 +115,9 @@ def load_config(args):
         if args.get('es_feed_schedd_queue') is None:
             args['es_feed_schedd_queue'] = es.getboolean(
                 'feed_schedd_queue', fallback=defaults['es_feed_schedd_queue'])
+        if args.get('es_feed_startd_history') is None:
+            if args['es_feed_startd_history'] = es.getboolean(
+                'feed_startd_history', fallback=defaults['es_feed_startd_history'])
         if args.get('es_index_name') is None:
             args['es_index_name'] = es.get(
                 'index_name', fallback=defaults['es_index_name'])

--- a/htcondor_es/utils.py
+++ b/htcondor_es/utils.py
@@ -116,7 +116,7 @@ def load_config(args):
             args['es_feed_schedd_queue'] = es.getboolean(
                 'feed_schedd_queue', fallback=defaults['es_feed_schedd_queue'])
         if args.get('es_feed_startd_history') is None:
-            if args['es_feed_startd_history'] = es.getboolean(
+            args['es_feed_startd_history'] = es.getboolean(
                 'feed_startd_history', fallback=defaults['es_feed_startd_history'])
         if args.get('es_index_name') is None:
             args['es_index_name'] = es.get(

--- a/htcondor_es/utils.py
+++ b/htcondor_es/utils.py
@@ -175,10 +175,10 @@ def get_startds(args=None):
         coll = htcondor.Collector(host)
         try:
             # get one ad per machine
-            startd_ads = coll.query(htcondor.AdTypes.Startd,
-                                          constraint = '(SlotType == "Static") || (SlotType == "Partitionable")',
-                                          projection = ["Name"])
-            for ad in startd_ads:
+            name_ads = coll.query(htcondor.AdTypes.Startd,
+                                      constraint = '(SlotType == "Static") || (SlotType == "Partitionable")',
+                                      projection = ["Name"])
+            for ad in name_ads:
                 try:
                     if ad["Name"][0:6] == "slot1@":
                         startd = coll.locate(htcondor.DaemonTypes.Startd, ad["Name"])

--- a/htcondor_es/utils.py
+++ b/htcondor_es/utils.py
@@ -75,6 +75,8 @@ def load_config(args):
         args['collectors'] = ','.join(list(config['COLLECTORS']))
     if (args.get('schedds') is None)    and ('SCHEDDS' in config)    and (len(list(config['SCHEDDS'])) > 0):
         args['schedds']    = ','.join(list(config['SCHEDDS']))
+    if (args.get('startds') is None)    and ('STARTDS' in config)    and (len(list(config['STARTDS'])) > 0):
+        args['startds']    = ','.join(list(config['STARTDS']))
     if 'PROCESS' in config:
         process = config['PROCESS']
         if args.get('process_schedd_history') is None:


### PR DESCRIPTION
1. Added configuration (process_startd_history, es_feed_startd_history)
2. Added get_startds function to get startd address ads
3. Added process_startd function and put call in process_histories

The ugliest part of this is that the same checkpoint file is used for
both schedds and startds. This will cause problems in the case where a
schedd and a startd reside on the same machine (and report to the same
collector). However, the checkpoint file is currently hardcoded in
process_histories, and it will take some major refactoring to make it
(yet another) commandline parameter.